### PR TITLE
fix: Add ci-status check required by branch protection

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,10 +6,11 @@ on:
   pull_request:
     branches: ['**']  # Run on PRs to any branch
 
-# Permissions required for path filtering action
+# Permissions required for path filtering action and status checks
 permissions:
   contents: read
   pull-requests: read
+  checks: write  # Required to create status checks
 
 jobs:
   # Detect which files changed to determine which jobs to run
@@ -321,4 +322,55 @@ jobs:
       run: ./gradlew bundleRelease --stacktrace
       continue-on-error: false
 
-  # Emulator Management Scripts Tests
+  # Final status check - required by branch protection
+  # This job creates the "ci-status" check that branch protection requires
+  ci-status:
+    needs: [changes, lint, accessibility, test, build-debug, build-release]
+    # Only run if app code changed (same condition as other jobs)
+    if: needs.changes.outputs.app-code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Create ci-status check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Determine if all required jobs succeeded or were skipped
+            const results = {
+              lint: '${{ needs.lint.result }}',
+              accessibility: '${{ needs.accessibility.result }}',
+              test: '${{ needs.test.result }}',
+              buildDebug: '${{ needs.build-debug.result }}',
+              buildRelease: '${{ needs.build-release.result }}'
+            };
+            
+            const allPassed = Object.values(results).every(
+              result => result === 'success' || result === 'skipped'
+            );
+            
+            const conclusion = allPassed ? 'success' : 'failure';
+            const message = allPassed 
+              ? 'All CI checks passed successfully'
+              : 'One or more CI checks failed';
+            
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'ci-status',
+              head_sha: context.sha,
+              status: 'completed',
+              conclusion: conclusion,
+              output: {
+                title: message,
+                summary: allPassed 
+                  ? 'All required CI checks (lint, accessibility, test, build-debug, build-release) have completed successfully.'
+                  : 'One or more required CI checks failed. Please review the workflow run for details.'
+              }
+            });
+            
+            // Exit with error if checks failed
+            if (!allPassed) {
+              core.setFailed(message);
+            }


### PR DESCRIPTION
This PR adds the missing `ci-status` check that branch protection requires.

**Problem:**
- PR #20 was blocked even though it had approval and all checks passing
- Branch protection requires a status check named `ci-status`
- The workflow wasn't creating this check

**Solution:**
- Added `ci-status` job that aggregates all CI check results
- Creates status check via GitHub API after all jobs complete
- Required to unblock PRs with branch protection enabled

**Changes:**
- Added `checks: write` permission for creating status checks
- Added `ci-status` job that depends on all CI jobs
- Job creates success/failure status based on all job results

This fix has already been applied to PR #20's branch and will unblock it once the workflow runs.