### PR TITLE
Fix GitHub Pages deployment - remove artifact_name parameter

### DIFF
--- a/.github/workflows/publish-document.yml
+++ b/.github/workflows/publish-document.yml
@@ -224,9 +224,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v3
-        with:
-          # Deploy from .github-pages directory
-          artifact_name: published-document
 
       - name: Deployment info
         run: |


### PR DESCRIPTION
Fixes deployment 404 error

- Remove artifact_name parameter from deploy-pages action
- Action should deploy from downloaded artifact path automatically