### PR TITLE
Fix GitHub Pages deployment - update to v4 actions

### DIFF
--- a/.github/workflows/publish-document.yml
+++ b/.github/workflows/publish-document.yml
@@ -197,7 +197,7 @@ jobs:
           EOF
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: .github-pages/
 
@@ -214,7 +214,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4
 
       - name: Deployment info
         run: |


### PR DESCRIPTION
Updates to latest GitHub Pages actions per official documentation

- upload-pages-artifact@v3 → @v4
- deploy-pages@v3 → @v4

This matches the official GitHub Pages deployment pattern.